### PR TITLE
Travis: make mogo-cxx-driver build less verbose

### DIFF
--- a/.travis.before_script
+++ b/.travis.before_script
@@ -1,5 +1,5 @@
 git clone -b 26compat https://github.com/mongodb/mongo-cxx-driver.git
 apt-get -qq install scons mongodb
 cd mongo-cxx-driver
-scons --prefix=/usr/local/ --full --use-system-boost --disable-warnings-as-errors
+scons --prefix=/usr/local/ -Q --full --use-system-boost --disable-warnings-as-errors > /dev/null
 #scons install


### PR DESCRIPTION
As described [here](https://github.com/ros-planning/warehouse_ros_mongo/pull/10#issuecomment-285897805), I believe Travis is failing because scons is outputting too much build console output while compiling mono-cxx-driver. This hack hides that output, at the cost of potentially being unable to see future problems with the compiled from source driver. Ideally, a binary will be released on this driver soon and we won't have to build it from source, so I'm happy with this hack.

``-Q`` also reduces [console output](http://scons.org/doc/HTML/scons-user.html#idm139837637957120), but from my testing it wasn't enough