### PR TITLE
replace deprecated std::auto_ptr

### DIFF
--- a/include/warehouse_ros_mongo/query_results.h
+++ b/include/warehouse_ros_mongo/query_results.h
@@ -49,7 +49,7 @@ namespace warehouse_ros_mongo
 {
 // To avoid some const-correctness issues we wrap Mongo's returned auto_ptr in
 // another pointer
-typedef std::auto_ptr<mongo::DBClientCursor> Cursor;
+typedef boost::shared_ptr<mongo::DBClientCursor> Cursor;
 typedef boost::shared_ptr<Cursor> CursorPtr;
 
 class MongoResultIterator : public warehouse_ros::ResultIteratorHelper

--- a/src/database_connection.cpp
+++ b/src/database_connection.cpp
@@ -111,7 +111,7 @@ string MongoDatabaseConnection::messageType(const string& db, const string& coll
   if (!isConnected())
     throw warehouse_ros::DbConnectException("Cannot look up metatable.");
   const string meta_ns = db + ".ros_message_collections";
-  std::auto_ptr<mongo::DBClientCursor> cursor = conn_->query(meta_ns, BSON("name" << coll));
+  boost::shared_ptr<mongo::DBClientCursor> cursor = conn_->query(meta_ns, BSON("name" << coll));
   mongo::BSONObj obj = cursor->next();
   return obj.getStringField("type");
 }


### PR DESCRIPTION
Accounts for message:
`warning: ‘template<class> class std::auto_ptr’ is deprecated [-Wdeprecated-declarations]`