### PR TITLE
Initialize mongo client only once

### DIFF
--- a/include/warehouse_ros_mongo/database_connection.h
+++ b/include/warehouse_ros_mongo/database_connection.h
@@ -68,12 +68,8 @@ protected:
   unsigned port_;
   float timeout_;
 
-  static bool initialized_;
-
   MessageCollectionHelper::Ptr openCollectionHelper(const std::string& db_name, const std::string& collection_name);
 };
-
-bool MongoDatabaseConnection::initialized_ = false;
 
 }  // namespace
 

--- a/include/warehouse_ros_mongo/database_connection.h
+++ b/include/warehouse_ros_mongo/database_connection.h
@@ -68,8 +68,12 @@ protected:
   unsigned port_;
   float timeout_;
 
+  static bool initialized_;
+
   MessageCollectionHelper::Ptr openCollectionHelper(const std::string& db_name, const std::string& collection_name);
 };
+
+bool MongoDatabaseConnection::initialized_ = false;
 
 }  // namespace
 

--- a/src/database_connection.cpp
+++ b/src/database_connection.cpp
@@ -46,7 +46,11 @@ using std::string;
 
 MongoDatabaseConnection::MongoDatabaseConnection() : host_("localhost"), port_(27017), timeout_(60.0)
 {
-  mongo::client::initialize();
+  if (!initialized_)
+  {
+    mongo::client::initialize();
+    initialized_ = true;
+  }
 }
 
 bool MongoDatabaseConnection::setParams(const string& host, unsigned port, float timeout)

--- a/src/database_connection.cpp
+++ b/src/database_connection.cpp
@@ -46,10 +46,12 @@ using std::string;
 
 MongoDatabaseConnection::MongoDatabaseConnection() : host_("localhost"), port_(27017), timeout_(60.0)
 {
-  if (!initialized_)
+  static bool initialized = false;  // Initialize only once
+  // libmongoclient 1.1.2 (in Bionic) doesn't require this anymore
+  if (!initialized)
   {
+    initialized = true;
     mongo::client::initialize();
-    initialized_ = true;
   }
 }
 


### PR DESCRIPTION
I get the following error (although saving and loading functions work) when using warehosue_ros_mongo in Ubuntu ~~16.04~~ 18.04 / ROS Melodic.


```bash
$ roslaunch panda_moveit_config demo.launch
# Press connect button of MotionPlanning Panel in Rviz.

...

2019-09-26T14:06:43.321+0900 Assertion: 17234:backgroundJob already running: PeriodicTaskRunner
2019-09-26T14:06:43.323+0900 0x7f1af2236709 0x7f1af2238444 0x7f1af222d619 0x7f1af222d6cc 0x7f1af223199c 0x7f1af2231dad 0x7f1af2201cfd 0x7f1af21b7a54 0x7f1af21b96c7 0x7f1af3bc8b51 0x7f1af3bc94c5 0x7f1af3bb8a5e 0x7f1af96e7782 0x7f1af9c49378 0x7f1c32087bcd 0x7f1c31e5e6db 0x7f1c32a5c88f 
 /home/leus/ws_moveit/devel/lib/libwarehouse_ros_mongo.so(_ZN5mongo15printStackTraceERSo+0x39) [0x7f1af2236709]
 /home/leus/ws_moveit/devel/lib/libwarehouse_ros_mongo.so(_ZN5mongo10logContextEPKc+0x224) [0x7f1af2238444]
 /home/leus/ws_moveit/devel/lib/libwarehouse_ros_mongo.so(_ZN5mongo11msgassertedEiPKc+0xd9) [0x7f1af222d619]
 /home/leus/ws_moveit/devel/lib/libwarehouse_ros_mongo.so(+0xf16cc) [0x7f1af222d6cc]
 /home/leus/ws_moveit/devel/lib/libwarehouse_ros_mongo.so(_ZN5mongo13BackgroundJob2goEv+0x48c) [0x7f1af223199c]
 /home/leus/ws_moveit/devel/lib/libwarehouse_ros_mongo.so(_ZN5mongo12PeriodicTask25startRunningPeriodicTasksEv+0x9d) [0x7f1af2231dad]
 /home/leus/ws_moveit/devel/lib/libwarehouse_ros_mongo.so(_ZN5mongo6client10initializeEb+0xcd) [0x7f1af2201cfd]
 /home/leus/ws_moveit/devel/lib/libwarehouse_ros_mongo.so(_ZN19warehouse_ros_mongo23MongoDatabaseConnectionC2Ev+0x7e) [0x7f1af21b7a54]
 /home/leus/ws_moveit/devel/lib/libwarehouse_ros_mongo.so(_ZNK12class_loader4impl10MetaObjectIN19warehouse_ros_mongo23MongoDatabaseConnectionEN13warehouse_ros18DatabaseConnectionEE6createEv+0x1b) [0x7f1af21b96c7]
 /home/leus/ws_moveit/devel/lib/libwarehouse_ros.so(_ZN12class_loader4impl14createInstanceIN13warehouse_ros18DatabaseConnectionEEEPT_RKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPNS_11ClassLoaderE+0x321) [0x7f1af3bc8b51]
 /home/leus/ws_moveit/devel/lib/libwarehouse_ros.so(_ZN9pluginlib11ClassLoaderIN13warehouse_ros18DatabaseConnectionEE20createUniqueInstanceERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE+0x225) [0x7f1af3bc94c5]
 /home/leus/ws_moveit/devel/lib/libwarehouse_ros.so(_ZN13warehouse_ros14DatabaseLoader12loadDatabaseEv+0x1de) [0x7f1af3bb8a5e]
 /home/leus/ws_moveit/devel/lib/libmoveit_warehouse.so.1.0.1(_ZN16moveit_warehouse12loadDatabaseEv+0x32) [0x7f1af96e7782]
 /home/leus/ws_moveit/devel/lib/libmoveit_move_group_interface.so.1.0.1(_ZN6moveit18planning_interface18MoveGroupInterface22MoveGroupInterfaceImpl34initializeConstraintsStorageThreadERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEj+0x38) [0x7f1af9c49378]
 /usr/lib/x86_64-linux-gnu/libboost_thread.so.1.65.1(+0x11bcd) [0x7f1c32087bcd]
 /lib/x86_64-linux-gnu/libpthread.so.0(+0x76db) [0x7f1c31e5e6db]
 /lib/x86_64-linux-gnu/libc.so.6(clone+0x3f) [0x7f1c32a5c88f]
[ERROR] [1569474403.323764588]: backgroundJob already running: PeriodicTaskRunner
```

This PR resolves this error. The cause of the error is that `mongo::client::initialize` is called multiple times (ref: https://jira.mongodb.org/browse/CXX-283 ).
`mongo::client::initialize` is called in [plugin constructor of `MongoDatabaseConnection` class](https://github.com/mmurooka/warehouse_ros_mongo/blob/jade-devel/src/database_connection.cpp#L49).
The plugin instance is generated from `moveit_warehouse::loadDatabase()`, which is called twice:
1. https://github.com/ros-planning/moveit/blob/master/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_context.cpp#L126
2. https://github.com/ros-planning/moveit/blob/master/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp#L1207 via https://github.com/ros-planning/moveit/blob/master/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_context.cpp#L202

This PR avoids to call `mongo::client::initialize` multiple times.
Without this PR, connecting to mongo successes first time (though above error is printed), but never successes onece disconnect and try to connect again.
