### PR TITLE
Fix cmake export of MONGODB dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 CATKIN_IGNORE
 .vscode
+__pycache__/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,11 @@
 cmake_minimum_required(VERSION 3.10.2)
 project(warehouse_ros_mongo)
 
-add_compile_options(-std=c++14)
+if(NOT "${CMAKE_CXX_STANDARD}")
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
@@ -14,20 +18,13 @@ find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(warehouse_ros REQUIRED)
 find_package(class_loader REQUIRED)
-find_package(Boost REQUIRED COMPONENTS system filesystem thread)
 find_package(OpenSSL REQUIRED)
 find_package(MONGODB REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 find_package(rclpy REQUIRED)
 
-# Install the python module for this package
-ament_python_install_package(${PROJECT_NAME})
-
-# At least gcc 7.4 has issues compiling against mongoclient with optimization > 1 enabled.
-# In this case, Labeler symbols LT, GT, etc. are null, causing weird results.
-if(CMAKE_COMPILER_IS_GNUCC)
-  add_compile_options(-O1)
-endif()
+# Find package for Boost component dependencies
+include(ConfigExtras.cmake)
 
 include(CheckIncludeFileCXX)
 check_include_file_cxx("mongo/version.h" HAVE_MONGO_VERSION_H)
@@ -42,6 +39,15 @@ endif()
 
 if(NOT MONGODB_EXPOSE_MACROS_FLAG)
   add_definitions(-DMONGO_EXPOSE_MACROS)
+endif()
+
+# Install the python module for this package
+ament_python_install_package(${PROJECT_NAME})
+
+# At least gcc 7.4 has issues compiling against mongoclient with optimization > 1 enabled.
+# In this case, Labeler symbols LT, GT, etc. are null, causing weird results.
+if(CMAKE_COMPILER_IS_GNUCC)
+  add_compile_options(-O1)
 endif()
 
 configure_file("include/${PROJECT_NAME}/config.h.in" "${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/config.h")
@@ -59,13 +65,11 @@ ament_target_dependencies(${PROJECT_NAME}
   std_msgs
   warehouse_ros
   class_loader
-  Boost
   OpenSSL
 )
 target_link_libraries(${PROJECT_NAME} ${MONGODB_LIBRARIES})
 
 if(BUILD_TESTING)
-
   find_package(launch_testing_ament_cmake)
   add_launch_test(test/warehouse_ros_mongo.launch.py)
 
@@ -80,8 +84,6 @@ endif()
 
 install(PROGRAMS ${PROJECT_NAME}/mongo_wrapper_ros.py DESTINATION lib/${PROJECT_NAME})
 
-install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION lib)
-
 install(DIRECTORY include/${PROJECT_NAME}/ DESTINATION include
         FILES_MATCHING PATTERN "*.h")
 #catkin_lint: ignore_once external_file
@@ -91,19 +93,33 @@ install(FILES "${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/config.h"
 install(FILES test/warehouse_ros_mongo.launch.py
         DESTINATION share/${PROJECT_NAME})
 
-ament_export_include_directories(include)
-ament_export_libraries(${PROJECT_NAME})
-ament_export_dependencies(ament_cmake)
-ament_export_dependencies(rclcpp)
-ament_export_dependencies(std_msgs)
-ament_export_dependencies(warehouse_ros)
-ament_export_dependencies(class_loader)
-ament_export_dependencies(Boost)
-ament_export_dependencies(OpenSSL)
-ament_export_dependencies(MONGODB)
-ament_export_dependencies(ament_cmake_python)
-ament_export_dependencies(rclpy)
+install(
+  FILES cmake/FindMONGODB.cmake
+  DESTINATION lib/cmake/${PROJECT_NAME}
+)
+
+install(
+  TARGETS ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
+)
+
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_dependencies(
+  ament_cmake
+  rclcpp
+  std_msgs
+  warehouse_ros
+  class_loader
+  OpenSSL
+  ament_cmake_python
+  rclpy
+  MONGODB
+)
 
 pluginlib_export_plugin_description_file(warehouse_ros mongo_database_connection_plugin_description.xml)
 
-ament_package()
+ament_package(CONFIG_EXTRAS ConfigExtras.cmake)

--- a/ConfigExtras.cmake
+++ b/ConfigExtras.cmake
@@ -1,0 +1,8 @@
+# Extras module needed for dependencies of warehouse_ros_mongo
+
+# This is needed so dependencies can find_package on MONGODB
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+
+# Boost component library dependencies have to be exported like this
+find_package(Boost REQUIRED COMPONENTS system filesystem thread)
+

--- a/package.xml
+++ b/package.xml
@@ -16,18 +16,18 @@
 
   <build_depend>libmongoclient-dev</build_depend>
 
+  <depend>mongodb</depend>
   <depend>warehouse_ros</depend>
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
   <depend>class_loader</depend>
   <depend>rclpy</depend>
 
-  <test_depend>mongodb</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_index_cpp</test_depend>
 
   <export>
-    <build_type>ament_cmake</build_type>  
+    <build_type>ament_cmake</build_type>
     <warehouse_ros plugin="${prefix}/mongo_database_connection_plugin_description.xml"/>
   </export>
 </package>


### PR DESCRIPTION
Signed-off-by: Tyler Weaver <tylerjw@gmail.com>

This fixes the issue I was experiencing here:
https://github.com/ros-planning/moveit2/pull/340#issuecomment-792965520

Please review and merge quickly so my PR for ament_lint tests can be unblocked and merged for WMD.  @henningkayser @JafarAbdi 