### PR TITLE
Fix installation path for FindMONGODB.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ install(FILES test/warehouse_ros_mongo.launch.py
 
 install(
   FILES cmake/FindMONGODB.cmake
-  DESTINATION lib/cmake/${PROJECT_NAME}
+  DESTINATION share/${PROJECT_NAME}/cmake
 )
 
 install(


### PR DESCRIPTION
Should fix https://travis-ci.com/github/ros-planning/moveit2/jobs/489453522

`CMAKE_CURRENT_LIST_DIR` points to `share/warehouse_ros_mongo/cmake` not `lib/cmake/warehouse_ros_mongo`