### PR TITLE
Add test_warehouse_ros_mongo_cpp in launch file test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,15 +75,12 @@ target_link_libraries(${PROJECT_NAME} ${MONGODB_LIBRARIES})
 
 if(BUILD_TESTING)
   find_package(launch_testing_ament_cmake)
-  add_launch_test(test/warehouse_ros_mongo.launch.py)
-
   find_package(ament_cmake_gtest REQUIRED)
-  ament_add_gtest(test_warehouse_ros_mongo_cpp test/test_warehouse_ros_mongo.cpp)
-  target_link_libraries(test_warehouse_ros_mongo_cpp warehouse_ros_mongo ${GTEST_LIBRARIES} ${OPENSSL_CRYPTO_LIBRARY})
 
-  install(TARGETS test_warehouse_ros_mongo_cpp
-    DESTINATION lib/${PROJECT_NAME}
-  )
+  ament_add_gtest_executable(test_warehouse_ros_mongo_cpp test/test_warehouse_ros_mongo.cpp)
+  target_link_libraries(test_warehouse_ros_mongo_cpp warehouse_ros_mongo ${GTEST_LIBRARIES} ${OPENSSL_CRYPTO_LIBRARY})
+  add_launch_test(test/warehouse_ros_mongo.launch.py
+    ARGS "test_binary_dir:=$<TARGET_FILE_DIR:test_warehouse_ros_mongo_cpp>")
 
   # ament_lint
   find_package(ament_lint_auto REQUIRED)

--- a/test/warehouse_ros_mongo.launch.py
+++ b/test/warehouse_ros_mongo.launch.py
@@ -1,23 +1,56 @@
+import unittest
+
 from launch import LaunchDescription
 from launch_ros.actions import Node
-from launch_testing.actions import ReadyToTest
+from launch.substitutions import PathJoinSubstitution, LaunchConfiguration
+from launch_testing.actions import ReadyToTest, GTest
+import launch_testing
+from launch_testing.asserts import assertExitCodes
 
 
 def generate_test_description():
-    return LaunchDescription(
-        [
-            Node(
-                package="warehouse_ros_mongo",
-                executable="mongo_wrapper_ros.py",
-                parameters=[
-                    {"warehouse_port": 33829},
-                    {"warehouse_host": "localhost"},
-                    {
-                        "warehouse_plugin": "warehouse_ros_mongo::MongoDatabaseConnection"
-                    },
-                ],
-                output="screen",
-            ),
-            ReadyToTest(),
-        ]
+    test_warehouse_ros_mongo_cpp = GTest(
+        path=[
+            PathJoinSubstitution(
+                [LaunchConfiguration("test_binary_dir"), "test_warehouse_ros_mongo_cpp"]
+            )
+        ],
+        output="screen",
     )
+    return (
+        LaunchDescription(
+            [
+                Node(
+                    package="warehouse_ros_mongo",
+                    executable="mongo_wrapper_ros.py",
+                    parameters=[
+                        {"warehouse_port": 33829},
+                        {"warehouse_host": "localhost"},
+                        {
+                            "warehouse_plugin": "warehouse_ros_mongo::MongoDatabaseConnection"
+                        },
+                    ],
+                    output="screen",
+                ),
+                test_warehouse_ros_mongo_cpp,
+                ReadyToTest(),
+            ]
+        ),
+        {"test_warehouse_ros_mongo_cpp": test_warehouse_ros_mongo_cpp},
+    )
+
+
+class TestTerminatingProcessStops(unittest.TestCase):
+    def test_gtest_run_complete(self, proc_info, test_warehouse_ros_mongo_cpp):
+        proc_info.assertWaitForShutdown(
+            process=test_warehouse_ros_mongo_cpp, timeout=60
+        )
+
+
+@launch_testing.post_shutdown_test()
+class TaskModelTestAfterShutdown(unittest.TestCase):
+    def test_exit_code(self, proc_info, test_warehouse_ros_mongo_cpp):
+        # Check that all processes in the launch exit with code 0
+        launch_testing.asserts.assertExitCodes(
+            proc_info, process=test_warehouse_ros_mongo_cpp
+        )


### PR DESCRIPTION
Fixes the failure in https://github.com/ros-planning/warehouse_ros_mongo/pull/52

The launch file for `warehouse_ros_mongo` & `test_warehouse_ros_mongo_cpp` need to run together