### PR TITLE
Use libssl-dev build_depend instead of openssl

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <build_depend>libmongoclient-dev</build_depend>
+  <build_depend>libssl-dev</build_depend>
 
   <depend>mongodb</depend>
   <depend>warehouse_ros</depend>


### PR DESCRIPTION
I should have run the pre-release test first. The required target was actually `libssl-dev`, just like here https://github.com/ros-planning/warehouse_ros/pull/68. The rolling pre-release test succeeded with this fix https://github.com/ros-planning/warehouse_ros_mongo/runs/2842969236?check_suite_focus=true, galactic is still failing because of missing warehouse_ros.