### PR TITLE
Clean OpenSSL dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(warehouse_ros REQUIRED)
 find_package(class_loader REQUIRED)
-find_package(OpenSSL REQUIRED)
 find_package(MONGODB REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 find_package(rclpy REQUIRED)
@@ -69,7 +68,6 @@ ament_target_dependencies(${PROJECT_NAME}
   std_msgs
   warehouse_ros
   class_loader
-  OpenSSL
 )
 target_link_libraries(${PROJECT_NAME} ${MONGODB_LIBRARIES})
 
@@ -78,7 +76,7 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
 
   ament_add_gtest_executable(test_warehouse_ros_mongo_cpp test/test_warehouse_ros_mongo.cpp)
-  target_link_libraries(test_warehouse_ros_mongo_cpp warehouse_ros_mongo ${GTEST_LIBRARIES} ${OPENSSL_CRYPTO_LIBRARY})
+  target_link_libraries(test_warehouse_ros_mongo_cpp warehouse_ros_mongo ${GTEST_LIBRARIES})
   add_launch_test(test/warehouse_ros_mongo.launch.py
     ARGS "test_binary_dir:=$<TARGET_FILE_DIR:test_warehouse_ros_mongo_cpp>")
 
@@ -119,7 +117,6 @@ ament_export_dependencies(
   std_msgs
   warehouse_ros
   class_loader
-  OpenSSL
   ament_cmake_python
   rclpy
   MONGODB

--- a/package.xml
+++ b/package.xml
@@ -15,7 +15,6 @@
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <build_depend>libmongoclient-dev</build_depend>
-  <build_depend>libssl-dev</build_depend>
 
   <depend>mongodb</depend>
   <depend>warehouse_ros</depend>
@@ -23,7 +22,6 @@
   <depend>std_msgs</depend>
   <depend>class_loader</depend>
   <depend>rclpy</depend>
-  <depend>openssl</depend>
 
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_ros</test_depend>


### PR DESCRIPTION
`warehouse_ros_mongo` does not use SSL directly, but through `warehouse_ros`. With the corrections from https://github.com/ros-planning/warehouse_ros/pull/80 we no longer need to specify OpenSSL depencies explicitly.